### PR TITLE
Make compatible with QGIS 2.x

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 /***************************************************************************
  ChinesePostman
@@ -7,6 +8,7 @@
         begin                : 2013-05-11
         copyright            : (C) 2013 by Ralf Kistner
         email                : ralf.kistner@gmail.com
+        git sha              : $Format:%H$
  ***************************************************************************/
 
 /***************************************************************************
@@ -19,27 +21,15 @@
  ***************************************************************************/
  This script initializes the plugin, making it known to QGIS.
 """
-def name():
-    return "Chinese Postman Solver"
-def description():
-    return "Chinese Postman Solver"
-def version():
-    return "0.1"
-def icon():
-    return "icon.png"
-def qgisMinimumVersion():
-    return "1.7"
-def author():
-    return "Ralf Kistner"
-def authorName():
-    return "Ralf Kistner"
-def email():
-    return "ralf.kistner@gmail.com"
-def experimental():
-    return True
-def homepage():
-    return "https://github.com/rkistner/chinese-postman"
-def classFactory(iface):
-    # load ChinesePostman class from file ChinesePostman
-    from chinesepostman import ChinesePostman
+
+
+# noinspection PyPep8Naming
+def classFactory(iface):  # pylint: disable=invalid-name
+    """Load ChinesePostman class from file ChinesePostman.
+
+    :param iface: A QGIS interface instance.
+    :type iface: QgsInterface
+    """
+    #
+    from .chinesepostman import ChinesePostman
     return ChinesePostman(iface)

--- a/metadata.txt
+++ b/metadata.txt
@@ -1,18 +1,41 @@
-# This file contains metadata for your plugin. Beginning
-# with version 1.8 this is the preferred way to supply information about a
-# plugin. The current method of embedding metadata in __init__.py will
-# be supported until version 2.0
+# This file contains metadata for your plugin. Since 
+# version 2.0 of QGIS this is the proper way to supply 
+# information about a plugin. The old method of 
+# embedding metadata in __init__.py will 
+# is no longer supported since version 2.0.
 
 # This file should be included when you package your plugin.
+# Mandatory items:
 
 [general]
 name=Chinese Postman Solver
 description=Chinese Postman Solver
-version=0.1
-qgisMinimumVersion=1.7
-class_name=ChinesePostman
+version=0.2
+qgisMinimumVersion=2.0
 homepage=https://github.com/rkistner/chinese-postman
 author=Ralf Kistner
 email=ralf.kistner@gmail.com
 
+about=Chinese Postman Solver solves the Chinese Postman problem, also 
+    known as CPP, postman tour or route inspection problem.
 
+tracker=https://github.com/rkistner/chinese-postman/issues
+repository=https://github.com/rkistner/chinese-postman
+# End of mandatory metadata
+
+# Recommended items:
+
+# Uncomment the following line and add your changelog:
+# changelog=
+
+# Tags are comma separated with spaces allowed
+tags=routing,network analysis,shortest
+
+homepage=https://github.com/rkistner/chinese-postman
+category=Plugins
+icon=icon.png
+# experimental flag
+experimental=True
+
+# deprecated flag (applies to the whole plugin, not just a single version)
+deprecated=False


### PR DESCRIPTION
- I used QGIS 2.8.3 with plugin Plugin Builder 2.10.1 to create a
sample plugin, then changed the files of Chinese Postman to resemble
those created by Plugin Builder.
- Not sure how it will work with versions of QGIS below 2.8. For
`qgisMinimumVersion`, I for now assumed compatibility with all 2.x
versions.
- Even though very little changed except for the metadata, it was not
possible to keep `qgisMinimumVersion` at 1.7, as QGIS then assumes the
plugin to be only compatible up to version 1.99.
- For error `AttributeError: 'unicode' object has no attribute
'toString'` I will create a separate commit, since I am not fully sure
if it has to do with the QGIS version.

Fixes rkistner/chinese-postman#2