### PR TITLE
Prevent AttributeError unicode object no toString

### DIFF
--- a/chinesepostman.py
+++ b/chinesepostman.py
@@ -125,7 +125,7 @@ def build_layer(graph, nodes, crs):
 
     # We want to set the CRS without prompting the user, so we disable prompting first
     s = QSettings()
-    oldValidation = s.value("/Projections/defaultBehaviour", "useGlobal").toString()
+    oldValidation = s.value("/Projections/defaultBehaviour", "useGlobal")
     s.setValue("/Projections/defaultBehaviour", "useGlobal")
 
     vl = QgsVectorLayer("LineString", "chinese_postman", "memory")


### PR DESCRIPTION
This patch is a fix for the following error:

`AttributeError: 'unicode' object has no attribute 'toString'`

Note: The error might be related to QGIS version 2.x only, not 1.x. The
effect of this patch on the plugin under QGIS 1.x has not been tested!