### PR TITLE
Remove duplicate entry of homepage in metadata

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -12,7 +12,6 @@ name=Chinese Postman Solver
 description=Chinese Postman Solver
 version=0.2.1
 qgisMinimumVersion=2.0
-homepage=https://github.com/rkistner/chinese-postman
 author=Ralf Kistner
 email=ralf.kistner@gmail.com
 


### PR DESCRIPTION
The current metadata.txt contains a duplicate entry for homepage. At least since QGIS 2.18.28, maybe some earlier versions as well, this leads to an error in the Plugin Manager:

    This plugin is broken
    Error reading metadata: general

This commit removes the duplicate entry.