### PR TITLE
Handle NetworkX 1.11 write_dot changes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ It should create a new layer with the results.
 Requirements:
 
 * Python2.7
-* [networkx](http://networkx.lanl.gov/)
+* [NetworkX](https://networkx.github.io/)
 
 
 Input data file must be in CSV format, with each row containing the following columns:

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,12 @@ Requirements:
 
 * Python2.7
 * [NetworkX](https://networkx.github.io/)
+* Optionally, if you want to export PNG images from the command line (not needed for using the QGIS-plugin):
+  * [Graphviz](https://graphviz.org/), and
+  * One of:
+    * For all NetworkX versions except 1.10: [PyGraphviz](https://pygraphviz.github.io/) (preferred), or
+    * For NetworkX <=1.10 and >=2.0: [pydot](https://github.com/pydot/pydot), or
+    * For NetworkX 1.10 and 1.11: [PyDotPlus](https://pydotplus.readthedocs.io/)
 
 
 Input data file must be in CSV format, with each row containing the following columns:
@@ -57,6 +63,11 @@ Then run (assuming the file is saved as input.csv):
 
 The segment ID and GPS coordinates in the input file are not used for any calculations, but are used for the CSV and GPX
 output.
+
+Use option `--png` to create a graph visualization of the route in PNG image format:
+
+    python postman.py --csv path.csv --gpx path.gpx --png path.png input.csv
+
 
 ## License
 

--- a/postman.py
+++ b/postman.py
@@ -223,7 +223,7 @@ def find_matchings(graph, n=5):
 
     The result may contain less than n matchings.
 
-    See http://networkx.lanl.gov/reference/generated/networkx.algorithms.matching.max_weight_matching.html
+    See https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.matching.max_weight_matching.html
     """
     best_matching = nx.max_weight_matching(graph, True)
     matchings = [best_matching]

--- a/postman.py
+++ b/postman.py
@@ -18,6 +18,24 @@ import csv
 import networkx as nx
 import xml.dom.minidom as minidom
 
+from distutils.version import LooseVersion
+
+if LooseVersion(nx.__version__) < LooseVersion('1.11'):
+    write_dot = nx.write_dot
+else:
+    try:
+        import pygraphviz
+        from networkx.drawing.nx_agraph import write_dot
+    except ImportError:
+        try:
+            if LooseVersion(nx.__version__) == LooseVersion('1.11'):
+                import pydotplus
+            else:
+                import pydot
+            from networkx.drawing.nx_pydot import write_dot
+        except ImportError:
+            from networkx.drawing.nx_agraph import write_dot
+
 def pairs(lst, circular=False):
     """
     Loop through all pairs of successive items in a list.
@@ -94,7 +112,7 @@ def make_png(graph, path):
     fd, dotfile = tempfile.mkstemp(prefix="graph", suffix=".dot")
     try:
         dfile = dotfile
-        nx.write_dot(graph, dfile)
+        write_dot(graph, dfile)
 
         subprocess.call(['neato', '-n2', '-Tpng', '-o', path, dfile])
     finally:


### PR DESCRIPTION
_From the commit message:_

When exporting a PNG graph visualization of the route (command-line option `--png`), NetworkX's `write_dot` function is called to write a temporary DOT-file to serve as input for Graphviz's `neato`, which creates the final bitmap image. NetworkX (NX) has two different `write_dot` functions:

- `nx.drawing.nx_agraph.write_dot()`, which depends on PyGraphviz.
- `nx.drawing.nx_pydot.write_dot()`, which depends on pydot or, in some NX versions, a pydot-fork.

Before NX 1.11, it was possible to just call `nx.write_dot()` and NX would check which dependencies were available and select which of the two functions to use. However, since NX 1.11, `nx_agraph` and `nx_pydot` are no longer imported into the main namespace ([1]), making a call to `nx.write_dot()` lead to the following error:

    Traceback (most recent call last):
      File "postman.py", line 379, in <module>
        make_png(eulerian_graph, args.png.name)
      File "postman.py", line 97, in make_png
        nx.write_dot(graph, dfile)
    AttributeError: 'module' object has no attribute 'write_dot'

The authors of NetworkX were aware that users (such as this program) now need to figure out themselves which function to use ([2]).

This commit introduces code to let Chinese Postman running on NX 1.11 or higher check which dependencies are available and import the correct `write_dot` function.

Tested with various combinations of NetworkX (1.7, 1.9, 1.10, 1.11, 2.2), PyGraphviz (1.3rc2, 1.4rc1, 1.5), pydot (1.0.28, 1.4.1), and PyDotPlus (2.0.2).

Design choices and alternatives
-------------------------------

- For NX versions below 1.11 the behavior is unchanged: NetworkX will choose which function to use. So, no changes for users that did not run into the error.
- (Back to NX 1.11 and higher again:) When dependencies for both `nx_agraph` and `nx_pydot` are available, we prefer `nx_agraph`. Considerations:
  - NX 1.7 and 1.9 also preferred `nx_agraph` over `nx_pydot`.
  - NX 1.10 preferred `nx_pydot`, but seemed buggy anyway, because it even chose `nx_pydot` if only PyGraphviz was available and then complained about missing pydot ([3]).
  - Example code distributed with NX 1.11 through 2.3 prefers `nx_agraph` over `nx_pydot` again ([4], [5]). This commit is partly based on that example code.
- Different than the NetworkX example code, we do not error if none of the dependencies is found. Instead, we just select the preferred `nx_agraph` and try with that. I experimented with emitting a warning, but felt that even that was not really worth the effort. Considerations:
  - We are at the top of the script, so we do not even know yet if the user requested PNG export. No need to error on an import that we might not be using anyway. Postponing the error or warning until we know if PNG export was requested would add complexity.
  - NX will report an error itself if it cannot find its dependencies. (However, `nx_pydot` only complains about missing pydot/pydotplus and `nx_pygraphviz` only asks for pygraphviz, so neither gives the user a complete overview.)
  - Our selection code is just a prediction of NetworkX's actual dependencies. (Future versions of) NetworkX may be looking for other modules. It might frustrate users then if we halt with an error without letting NX give it a try. Even a warning may turn out to be wrong and cause confusion.
  - Given the complex history of NX dependencies, it is difficult to generate a dynamic warning text telling the user which dependency to install for his NX version. A static warning text would just be a repetition of or a reference to the requirements mentioned in the Readme, so would not add much value.
  - Because we do not check dependencies for NX versions below 1.11, we cannot give a warning in every case of missing dependencies. The lack of a warning may become a source of confusion by itself.
  - The new code checks the availability of the NX dependencies by importing them, even though `postman.py` does not actually need them itself. I checked if it was possible to check for a module's existence without importing it, but that seems to need further imports and different approaches for different Python versions ([6]), so in the end, I decided against it.
- I chose to place the new imports at the top of the script. This seems to be generally favored over importing inside a function for reasons of coding style and dependency tracking ([7], [8], [9]). However, the downside is that the imports will be made even if the user did not request PNG export. The maximum performance impact I saw was 40 ms on repeated runs from the command-line, or 0.4 ms on repeated runs from within Python (see below for details). As an alternative to import at the top, the import could be done in `make_png()`, or placed in a new function or file ([10]) to be called from `make_png()`. I would not move it to the `__main__` part (after command-line argument parsing) though, because then it would not run if another module calls the `make_png()` function directly.
- I use `LooseVersion()` to determine the NX version. This is prone to misunderstanding special version numbers such as release candidates (e.g. 1.11rc3), but I chose it because it should always be available. Alternatively, consider `pkg_resources.parse_version`. See my comments in PR 18 ([11]).

Additional findings
-------------------

- Which pydot-forks work with which versions of NetworkX:
  - NX 1.7, 1.9, 2.0, 2.1, 2.2, 2.3: `pydot` exclusively.
  - NX 1.10: `pydot`, `pydotplus`, or `pydot-ng`.
  - NX 1.11: `pydotplus` exclusively.
- With pydot and PyDotPlus, PNG export results in `syntax error in line 2 near ']'` from Graphviz's `neato`. The workaround is to change or comment out `id_re_num` in the pydot source code. This is a separate issue with pydot/pydotplus and unrelated to this commit.
- Performance of the new code introduced by this commit:
  - Methodology: First I measured the execution time of the entire program started from the command-line using bash's `time`, then of only the new code block within Python using Python's `timeit`. Both were performed using a single thread on a Celeron N3350. I measured repeated runs, so there was caching involved. A single/first run will be more affected because of disk I/O, although I never found it noticable myself. I used a minimal test graph of 4 nodes connected as a square and selected CSV and GPX export. PNG export was not selected, because it only works after the fix. All results are in milliseconds (ms) per run (lower is better).
  - Results: On the command-line, there was no clear performance loss in case none of the dependencies (PyGraphviz, pydot, PyDotPlus) was installed. When one or more of them was installed, the maximum performance loss was 40 ms. For comparison: Baseline performance (before adding the new code) was 520 or 800 ms, depending on the NX version. From within Python, the performance impact was much lower: Best if PyGraphviz was installed (0.04 ms), worst if nothing was installed (0.4 ms) and in the middle if pydot/PyDotPlus was installed (0.2 ms). This probably reflects the time spent on going through the logic of the new code, with the imports themselves not taking up much time thanks to Python import caching.
  - Conclusions: For occasional use, the performance hit of the code introduced by this commit seems acceptable relative to the execution time of the rest of the program and the route calculation time. Users looking for high performance on repeated calls should try to make those repeated calls from within the same Python session. Making sure PyGraphviz is installed further reduces the slowdown to around 0.04 ms. If it is not possible to stay in Python between repeated calls, and PNG export is not needed, the best bet seems to be not having any of PyGraphviz, pydot, PyDotPlus installed at all, which should reduce the slowdown to around 0.4 ms.

[1]: https://github.com/networkx/networkx/pull/1930
[2]: https://github.com/networkx/networkx/pull/1924#issuecomment-170421481
[3]: https://github.com/networkx/networkx/issues/1882#issuecomment-170294975
[4]: https://github.com/networkx/networkx/blob/networkx-2.3/examples/drawing/plot_lanl_routes.py#L24
[5]: https://github.com/networkx/networkx/blob/networkx-2.3/examples/drawing/plot_circular_tree.py#L11
[6]: https://stackoverflow.com/questions/14050281/how-to-check-if-a-python-module-exists-without-importing-it
[7]: https://stackoverflow.com/questions/477096/python-import-coding-style/
[8]: https://stackoverflow.com/questions/128478/should-import-statements-always-be-at-the-top-of-a-module#
[9]: https://stackoverflow.com/questions/3095071/in-python-what-happens-when-you-import-inside-of-a-function#
[10]: https://stackoverflow.com/questions/6793748/python-doing-conditional-imports-the-right-way
[11]: https://github.com/rkistner/chinese-postman/pull/18#issuecomment-488639869